### PR TITLE
Add website ideas to help.txt files based on physical stores

### DIFF
--- a/web_pages/entertainment/games/help.txt
+++ b/web_pages/entertainment/games/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **Restaurant Simulation Game:** Inspired by "fast food," "pizza," "cafe," etc. Players could manage their own virtual eatery, from cooking to customer service.
+- **Retail Tycoon Game:** Drawing from "department stores," "groceries," "apparel." Players build and manage a retail empire, deciding on inventory, pricing, and store layout.
+- **Repair/Fix-it-Up Game:** Based on "repair shops" or "home improvement." Players could fix various items, from electronics to cars, or renovate houses.
+- **Hidden Object/Collector Game:** Inspired by "knick knacks" or "hobby stores." Players search for and collect various themed items in different scenes.
+- **Farming/Market Simulator:** From "farmers market" and "farm stuff." Players could grow crops, raise animals, and sell their products at a virtual market.

--- a/web_pages/entertainment/social_media/help.txt
+++ b/web_pages/entertainment/social_media/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **Local Foodie/Shopping Communities:** Inspired by "fast food," "restaurants," "farmers market," "department stores." A platform for users to share reviews, photos, and recommendations for local eateries and shops.
+- **DIY & Home Improvement Showcase:** Based on "hobby stores," "home improvement," "furniture." A social network where users share their DIY projects, home renovation progress, and crafting ideas.
+- **Automotive Enthusiast Groups:** Drawing from "automobiles," "repair shops." A platform for car lovers to discuss models, share modification projects, and organize local meetups.
+- **Style & Apparel Sharing Platform:** Inspired by "apparel." Users can post their outfits, get feedback, discover new brands, and follow fashion influencers.
+- **Pop-up Event & Market Finder:** Based on "farmers market," "knick knacks." A social tool for discovering and sharing information about local pop-up shops, markets, and unique vendor events.

--- a/web_pages/information/abouts/help.txt
+++ b/web_pages/information/abouts/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **"About Us" for Local Businesses:** Drawing from all store types. A template or service to help small physical businesses (cafes, repair shops, boutiques) create compelling "About Us" pages for their websites, detailing their history, mission, and what makes them unique.
+- **History of Retail/Cuisine Types:** Inspired by "department stores," "fast food," "pizza," "chinese," "indian," etc. Informational content detailing the history and evolution of different retail sectors or specific cuisine types.
+- **"Meet the Maker/Artisan" Directory:** Based on "hobby stores," "farmers market," "knick knacks." An "Abouts" site profiling local artisans, craftspeople, and farmers, telling their stories and showcasing their products.
+- **Franchise Information Hub:** For "fast food" chains or other franchised businesses. An informational site explaining how franchising works for specific brands, the costs involved, and stories of franchisees.
+- **Store Experience Explainer:** Describing what to expect from different store types, e.g., "What is a Diner?", "The Farmers Market Experience," "Navigating a Department Store."

--- a/web_pages/information/news/help.txt
+++ b/web_pages/information/news/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **Local Business Opening/Closing News:** Covering new restaurant launches, store closures, changes in ownership for local physical businesses.
+- **Retail Industry News Section:** Focusing on news about "department stores," "groceries," "apparel," including trends, financial performance, and major announcements from big chains.
+- **Consumer Trends & Reports:** News articles analyzing consumer behavior related to different store types (e.g., "Shift towards online grocery shopping," "Boom in fast casual dining," "Home improvement spending trends").
+- **Supply Chain News for Retail/Food:** News related to the supply chains that support physical stores, like "farmers market" suppliers, or issues affecting "electronics" availability.
+- **Real Estate News for Commercial Properties:** Reporting on new developments for shopping centers, restaurant spaces, or the impact of e-commerce on physical retail footprints.

--- a/web_pages/information/trivia/help.txt
+++ b/web_pages/information/trivia/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **Restaurant & Food Trivia:** Questions about different cuisines ("chinese," "indian," "mexican"), famous dishes from "pizza" places or "diners," history of "fast food" chains.
+- **Retail History Trivia:** Trivia about iconic "department stores," origins of common "apparel" brands, or historical "automobiles."
+- **"Guess the Store/Product" Game:** Image-based trivia where users guess the store type (e.g., a "cafe" interior, a "hobby store" shelf) or a specific product found in "electronics" stores or "groceries."
+- **Home Improvement & DIY Trivia:** Questions about tools found in "home improvement" stores, materials, or famous architectural styles.
+- **Brand Slogan & Jingle Trivia:** Trivia focusing on well-known slogans or jingles from various physical store types or brands sold within them.

--- a/web_pages/stores/virtual/help.txt
+++ b/web_pages/stores/virtual/help.txt
@@ -1,1 +1,9 @@
-The 
+The
+
+## Website Ideas based on Physical Store Types
+
+- **Curated Online Marketplace for Local Artisans:** Mirroring a "farmers market" or "knick knacks" store, but online. A platform for local craftspeople to sell their goods.
+- **Specialty Food Subscription Boxes:** Inspired by "fast premium," "mexican," "indian," "chinese." Virtual stores offering curated subscription boxes for specific cuisines or food types (e.g., gourmet pasta kits, international snack boxes).
+- **Virtual Department Store with Themed Boutiques:** An e-commerce site structured like a "department store" but with distinct virtual "boutiques" for "apparel," "electronics," "home goods" (inspired by "furniture"), perhaps with a focus on independent brands.
+- **Online DIY Project Kits & Supplies:** Based on "hobby stores" or "home improvement." A virtual store selling kits and supplies for specific DIY projects, from crafting to home repair.
+- **Customizable Furniture/Apparel E-Shop:** Drawing from "furniture" and "apparel." An online store where customers can customize products (e.g., choose fabrics for a sofa, design their own t-shirt) before ordering.

--- a/web_pages/tools/help.txt
+++ b/web_pages/tools/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **Restaurant Menu Generator Tool:** Inspired by all restaurant types. A tool for small restaurants ("cafes," "diners," "fast food") to easily create and update professional-looking menus.
+- **Inventory Management Tool for Small Retailers:** Based on "groceries," "hobby stores," "apparel." A simple tool for small physical retailers to track inventory, sales, and reorder points.
+- **Local Delivery Route Optimizer:** For businesses that might offer delivery, like "pizza" places or local "groceries." A tool to plan the most efficient delivery routes.
+- **DIY Project Planner & Shopping List Generator:** Drawing from "home improvement" or "hobby stores." A tool where users can plan a project, and it generates a list of materials and tools needed, possibly with links to buy them or check local store availability.
+- **Store Layout Planner Tool:** For various retail types like "department stores," "furniture," or even "farmers market" stallholders. A basic tool to sketch out and optimize store layouts.

--- a/web_pages/work/HR/help.txt
+++ b/web_pages/work/HR/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **Retail/Hospitality Staff Training Platform:** For "department stores," "fast food," "cafes." An HR tool providing online training modules for customer service, sales techniques, food safety, specific to retail and hospitality environments.
+- **Employee Scheduling Software for Shift-Based Businesses:** Useful for "restaurants," "groceries," "bars." An HR tool to help managers create and manage staff schedules for businesses with variable shifts.
+- **Franchise Onboarding & Compliance Portal:** For HR departments of "fast food" chains or other franchised businesses. A platform to manage onboarding of new franchisees and ensure compliance with brand standards and HR policies.
+- **Skills Matching for Specialized Retail/Repair:** For "automobiles," "electronics repair shops," "home improvement" (specialized departments). An HR tool to identify and track employee skills and certifications, matching them to specific job requirements or customer needs.
+- **Uniform Management & Ordering System:** For businesses requiring uniforms, like many "restaurants," "department stores," "apparel" stores (for staff). An HR-linked tool to manage uniform inventory, employee orders, and distribution.

--- a/web_pages/work/job_boards/help.txt
+++ b/web_pages/work/job_boards/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **Job Board for Local Retail & Service Businesses:** Specifically listing openings in "fast food," "cafes," "boutiques," "repair shops," "groceries" within a certain geographic area.
+- **Specialized Job Board for Skilled Trades:** Focusing on jobs in "automobiles" (mechanics), "home improvement" (plumbers, electricians), "electronics repair" technicians.
+- **Management & Supervisory Roles in Retail/Hospitality:** A niche job board for manager-level positions in "department stores," restaurant chains ("pizza," "fast premium"), "hotels" (though not explicitly listed, "bars" and "cafes" are close).
+- **Temporary & Seasonal Work Finder for Retail:** Connecting job seekers with temporary positions in "department stores" during holidays, "farmers markets" for seasonal work, or event staff for "bars."
+- **Franchise Staffing Job Board:** A platform for franchisees of large chains ("fast food," "fast coffee") to advertise job openings for their specific locations.

--- a/web_pages/work/logging/help.txt
+++ b/web_pages/work/logging/help.txt
@@ -1,1 +1,9 @@
 Hello
+
+## Website Ideas based on Physical Store Types
+
+- **Sales & Customer Traffic Logger for Retail:** A tool for "department stores," "apparel" shops, or any retail outlet to log daily sales figures, customer foot traffic (if manually tracked or via sensors), and perhaps notes on promotions or events.
+- **Restaurant Operations Log:** For "fast food," "diners," "cafes" to log daily opening/closing procedures, food safety checks, inventory spoilage, customer complaints/feedback, and maintenance issues.
+- **Vehicle Maintenance & Repair Log (for businesses):** For companies managing a fleet of "automobiles" (e.g., delivery services linked to "pizza" or "groceries") or for "repair shops" themselves to log customer vehicle repair histories.
+- **Farm Operations Log:** For "farmers markets" (the suppliers) or "farm stuff" retailers. Logging planting schedules, harvest yields, pest control measures, equipment maintenance.
+- **Store Maintenance & Cleaning Schedule Logger:** A tool for any physical store ("ice cream" parlors, "hobby stores," "furniture" stores) to track and log cleaning schedules, equipment maintenance (e.g., for "fast coffee" machines), and repair requests.


### PR DESCRIPTION
This commit updates various help.txt files across different website categories (entertainment, information, stores, tools, work).

The ideas were generated by taking inspiration from the list of physical store types found in `web_pages/stores/physical/help.txt`. Each help.txt file now includes a new section with 3-5 high-level website feature or content ideas relevant to its specific category, derived from these physical store concepts.

This aims to provide a richer set of brainstorming prompts within each category's help file.